### PR TITLE
add space-vim-dark colors for easymotion hints

### DIFF
--- a/colors/space-vim-dark.vim
+++ b/colors/space-vim-dark.vim
@@ -339,6 +339,11 @@ call s:hi('pythonSpaceError'      , 196 , '' , 'none' , 'none')
 hi link ALEErrorSign    Error
 hi link ALEWarningSign  Warning
 
+" vim-easymotion
+call s:hi('EasyMotionTarget', 76, '', 'none', 'none')
+call s:hi('EasyMotionTarget2First', 76, '', 'none', 'none')
+call s:hi('EasyMotionTarget2Second', 36, '', 'none', 'none')
+
 " vim-markdown
 call s:hi('htmlH1' , 68  , '' , 'bold' , 'bold')
 call s:hi('htmlH2' , 36  , '' , 'bold' , 'bold')


### PR DESCRIPTION
First off, thank you for the creating these beautiful color schemes!

I've added colors for [vim-easymotion](https://github.com/easymotion/vim-easymotion) movement hints to `space-vim-dark.vim`; feel free to merge or not depending on whether you think this would be helpful for others.

Cheers.