### PR TITLE
Change symbol bg color for "git-gutter" plugin.

### DIFF
--- a/colors/space-vim-dark.vim
+++ b/colors/space-vim-dark.vim
@@ -358,10 +358,10 @@ call s:hi('IndentGuidesOdd'  , '' , 237 , 'none' , 'none')
 call s:hi('IndentGuidesEven' , '' , 239 , 'none' , 'none')
 
 " vim-gitgutter
-call s:hi('GitGutterAdd'          , 36  , '' , 'none' , 'none')
-call s:hi('GitGutterChange'       , 178 , '' , 'none' , 'none')
-call s:hi('GitGutterDelete'       , 160 , '' , 'none' , 'none')
-call s:hi('GitGutterChangeDelete' , 140 , '' , 'none' , 'none')
+call s:hi('GitGutterAdd'          , 36  , 234 , 'none' , 'none')
+call s:hi('GitGutterChange'       , 178 , 234 , 'none' , 'none')
+call s:hi('GitGutterDelete'       , 160 , 234 , 'none' , 'none')
+call s:hi('GitGutterChangeDelete' , 140 , 234 , 'none' , 'none')
 
 " vim-signify
 call s:hi('SignifySignAdd'         , 36  , '' , 'none' , 'none')


### PR DESCRIPTION
The "git-gutter" plugin sets the symbols bg color the same as the line
color. This way the correct bg color is set for git-gutter symbols.