### PR TITLE
Add space-vim-dark Xresources theme

### DIFF
--- a/terminal/space-vim-dark.xresources
+++ b/terminal/space-vim-dark.xresources
@@ -1,0 +1,112 @@
+! Space-Vim-Dark Colour scheme
+! -----------------------------
+! Colour scheme for X based on
+! the space-vim-dark Vim theme
+! -----------------------------
+
+! Colour Codes
+! 0,8  => Black
+! 1,9  => Red
+! 2,10 => Green
+! 3,11 => Yellow
+! 4,12 => Blue
+! 5,13 => Magenta
+! 6,14 => Cyan
+! 7,15 => White
+
+! Base16 Colour Mappings
+! foreground  => base05
+! background  => base00
+! cursorColor => base05
+! color0      => base00
+! color1      => base08
+! color2      => base0B
+! color3      => base0A
+! color4      => base0D
+! color5      => base0E
+! color6      => base0C
+! color7      => base05
+! color8      => base03
+! color9      => base09
+! color10     => base01
+! color11     => base02
+! color12     => base04
+! color13     => base06
+! color14     => base0F
+! color15     => base07
+! color16     => base09
+! color17     => base0F
+! color18     => base01
+! color19     => base02
+! color20     => base04
+! color21     => base06
+
+! Colours can be set like
+! * magenta      -- Xterm
+! * yellow3      -- Xterm
+! * #21ff4c      -- Hex
+! * rgb:5c/21/ff -- RGB
+! Transparency
+! * rgba:0000/0000/0200/c800
+
+
+! 'Base16' Style colour definitions
+! this allows for greater portability
+#define base00 #262626
+#define base01 #96e931
+#define base02 #e89e0f
+#define base03 #555f69
+#define base04 #4083cd
+#define base05 #a3a3a3
+#define base06 #d358d5
+#define base07 #dfdfdf
+#define base08 #cb4674
+#define base09 #fc4474
+#define base0A #a18417
+#define base0B #74d55c
+#define base0C #25919e
+#define base0D #627ad2
+#define base0E #91429d
+#define base0F #22abbb
+
+! Alternative colours
+! base00 #1f2022
+! base05 #c1c1c1
+
+
+! Set the colours from the colour definitions
+*.foreground:  base05
+#ifdef background_opacity
+*.background:  [background_opacity]base00
+#else
+*.background:  base00
+#endif
+*.cursorColor: base05
+
+*.color0:  base00
+*.color1:  base08
+*.color2:  base0B
+*.color3:  base0A
+*.color4:  base0D
+*.color5:  base0E
+*.color6:  base0C
+*.color7:  base05
+
+*.color8:  base03
+*.color9:  base09
+*.color10: base01
+*.color11: base02
+*.color12: base04
+*.color13: base06
+*.color14: base0F
+*.color15: base07
+
+*.color16: base09
+*.color17: base0F
+*.color18: base01
+*.color19: base02
+*.color20: base04
+*.color21: base06
+
+
+! vim: ft=xdefaults

--- a/terminal/space-vim-dark.xresources
+++ b/terminal/space-vim-dark.xresources
@@ -4,6 +4,14 @@
 ! the space-vim-dark Vim theme
 ! -----------------------------
 
+! To use this colour scheme for X based applications (e.g. Xterm, URxvt, etc.):
+!   1. Copy all lines from this file which are not comments (comments are lines
+!      which begin with a `!`) into your `~/.Xresources` file.
+!   2. Reload your configuration file with: `xrdb ~/.Xresources`. 
+!
+!   Note: More experienced users may wish to use the `#include` functionality in
+!      X configuration.
+
 ! Colour Codes
 ! 0,8  => Black
 ! 1,9  => Red
@@ -41,6 +49,24 @@
 ! color20     => base04
 ! color21     => base06
 
+! Base16 Colour Descriptions
+! base00 - Default Background
+! base01 - Lighter Background (Used for status bars)
+! base02 - Selection Background
+! base03 - Comments, Invisibles, Line Highlighting
+! base04 - Dark Foreground (Used for status bars)
+! base05 - Default Foreground, Caret, Delimiters, Operators
+! base06 - Light Foreground (Not often used)
+! base07 - Light Background (Not often used)
+! base08 - Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+! base09 - Integers, Boolean, Constants, XML Attributes, Markup Link Url
+! base0A - Classes, Markup Bold, Search Text Background
+! base0B - Strings, Inherited Class, Markup Code, Diff Inserted
+! base0C - Support, Regular Expressions, Escape Characters, Markup Quotes
+! base0D - Functions, Methods, Attribute IDs, Headings
+! base0E - Keywords, Storage, Selector, Markup Italic, Diff Changed
+! base0F - Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?>
+
 ! Colours can be set like
 ! * magenta      -- Xterm
 ! * yellow3      -- Xterm
@@ -51,7 +77,8 @@
 
 
 ! 'Base16' Style colour definitions
-! this allows for greater portability
+! this allows for greater portability 
+! (http://chriskempson.com/projects/base16/)
 #define base00 #262626
 #define base01 #96e931
 #define base02 #e89e0f
@@ -64,14 +91,10 @@
 #define base09 #fc4474
 #define base0A #a18417
 #define base0B #74d55c
-#define base0C #25919e
+#define base0C #af87d7
 #define base0D #627ad2
 #define base0E #91429d
 #define base0F #22abbb
-
-! Alternative colours
-! base00 #1f2022
-! base05 #c1c1c1
 
 
 ! Set the colours from the colour definitions
@@ -83,6 +106,7 @@
 #endif
 *.cursorColor: base05
 
+! Dark colours
 *.color0:  base00
 *.color1:  base08
 *.color2:  base0B
@@ -92,6 +116,7 @@
 *.color6:  base0C
 *.color7:  base05
 
+! Light colours
 *.color8:  base03
 *.color9:  base09
 *.color10: base01
@@ -101,6 +126,7 @@
 *.color14: base0F
 *.color15: base07
 
+! Additional colours (may not be displayed in some terminals)
 *.color16: base09
 *.color17: base0F
 *.color18: base01
@@ -109,4 +135,4 @@
 *.color21: base06
 
 
-! vim: ft=xdefaults
+! vim: ft=xdefaults :


### PR DESCRIPTION
This will allow X based applications (such as, Xterm & URxvt), to use the beautiful Space-Vim-Dark theme.

This will partly solve issue #10.

The colours still need switching around (make the purple the main colour?), but it is using all (16) of the main space-vim-dark colours.

Feedback is appreciated. @liuchengxu feel free to modify, and criticise my this.  😄 

### To Do

- [x] Create initial version of the Xresources version,
- [x] Fix the colours (to emphasise the violet colours),
- [x] Write usage documentation,

### Images of initial version in URxvt

![first-version](https://user-images.githubusercontent.com/26504626/33906142-ec49ef16-df78-11e7-9bdb-4da04e6545e4.png)

![first-version-htop](https://user-images.githubusercontent.com/26504626/33906223-365056d6-df79-11e7-9a2d-5e7b95a74e06.png)

#### Comparison to Vim in URxvt using Space-Vim-Dark colour scheme

![vim-space-vim-dark](https://user-images.githubusercontent.com/26504626/33907297-94f4dd9e-df7c-11e7-9ff9-38e93fc46b09.png)
