### PR TITLE
Increase contrast for spelling errors

### DIFF
--- a/colors/space-vim-dark.vim
+++ b/colors/space-vim-dark.vim
@@ -200,8 +200,8 @@ call s:hi('SpecialKey'     , 59  , '' , 'None' , 'None')
 call s:hi('SpecialChar'    , 171 , '' , 'bold' , 'bold')
 call s:hi('SpecialComment' , 243  , '' , 'None' , 'None')
 
-call s:hi('SpellBad'   , 168 , '' , 'underline' , 'undercurl')
-call s:hi('SpellCap'   , 110 , '' , 'underline' , 'undercurl')
+call s:hi('SpellBad'   , 168 , 52 , 'underline' , 'undercurl')
+call s:hi('SpellCap'   , 110 , 25 , 'underline' , 'undercurl')
 call s:hi('SpellLocal' , 253 , '' , 'underline' , 'undercurl')
 call s:hi('SpellRare'  , 218 , '' , 'underline' , 'undercurl')
 


### PR DESCRIPTION
When using `:set spell`, spelling and capitalization mistakes were
nearly illegible because the text and background were both light
colors.  This commit increases the lightness of the background color
for these cases to increase contrast.

Before:
![screenshot 2018-12-16 at 10 15 20 am](https://user-images.githubusercontent.com/777773/50062808-02f9f500-015e-11e9-9ed9-a683f5ad6b31.png)

After:
![screenshot 2018-12-16 at 10 19 15 am](https://user-images.githubusercontent.com/777773/50062779-d5ad4700-015d-11e9-8c6d-e888cd79eb4f.png)
